### PR TITLE
Add Go→Python→Node fallback for site crawling and local TF-IDF QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ MetaCrawler is a full-stack AI-powered web scraping platform that combines Pytho
 - `GET /health`
 - `POST /scrape/quick`
 - `POST /analyze`
+- `POST /site/crawl-and-train`
+- `POST /site/ask`
 
 ### Go service (`:8080`)
 - `GET /health`
 - `POST /scrape`
+- `POST /crawl`
 
 ### Node service (`:3000`)
 - `GET /health`
@@ -84,3 +87,27 @@ Set in frontend shell if needed:
 ```bash
 export NEXT_PUBLIC_GRAPHQL_URL=http://localhost:4000/graphql
 ```
+
+
+## Site-aware crawling and local QA
+
+The Python service can now build a local retrieval model from a single site and answer questions from that site corpus.
+
+1. Crawl and train a local model (respects `robots.txt`):
+
+```bash
+curl -X POST http://localhost:8000/site/crawl-and-train \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com","max_pages":25,"max_depth":2}'
+```
+
+2. Ask questions against the trained site model:
+
+```bash
+curl -X POST http://localhost:8000/site/ask \
+  -H 'Content-Type: application/json' \
+  -d '{"question":"What products are offered?","top_k":3}'
+```
+
+The first endpoint uses the Go crawler (`/crawl`) as the primary concurrent engine, falls back to the Python crawler if Go fails or yields no pages, and finally falls back to the Node scraper (`/scrape`) if needed. It stores crawl output under `backend-python/data/` and trains a local TF-IDF retriever (no paid APIs).
+

--- a/api-gateway/resolvers.js
+++ b/api-gateway/resolvers.js
@@ -112,7 +112,11 @@ async function dispatchJob(input) {
   }
 
   if (type === 'static') {
-    return callService(`${SERVICE_URLS.static}/scrape`, { url });
+    try {
+      return await callService(`${SERVICE_URLS.static}/scrape`, { url });
+    } catch (_error) {
+      return callService(`${SERVICE_URLS.ai}/scrape/quick`, { url });
+    }
   }
   if (type === 'dynamic') {
     return callService(`${SERVICE_URLS.dynamic}/scrape`, { url, selector });

--- a/backend-go/cmd/server/main.go
+++ b/backend-go/cmd/server/main.go
@@ -13,10 +13,18 @@ type scrapeRequest struct {
 	URL string `json:"url"`
 }
 
+type crawlRequest struct {
+	URL      string `json:"url"`
+	MaxPages int    `json:"max_pages"`
+	MaxDepth int    `json:"max_depth"`
+	Workers  int    `json:"workers"`
+}
+
 func main() {
 	http.HandleFunc("/", healthCheck)
 	http.HandleFunc("/health", healthCheck)
 	http.HandleFunc("/scrape", submitScrapeJob)
+	http.HandleFunc("/crawl", submitCrawlJob)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -51,6 +59,28 @@ func submitScrapeJob(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func submitCrawlJob(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req crawlRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.URL == "" {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	result := scraper.Crawl(req.URL, scraper.CrawlOptions{
+		MaxPages: req.MaxPages,
+		MaxDepth: req.MaxDepth,
+		Workers:  req.Workers,
+	})
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)

--- a/backend-go/internal/scraper/crawler.go
+++ b/backend-go/internal/scraper/crawler.go
@@ -1,0 +1,209 @@
+package scraper
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+type CrawlPage struct {
+	URL   string `json:"url"`
+	Title string `json:"title"`
+	Text  string `json:"text"`
+}
+
+type CrawlResult struct {
+	SeedURL     string      `json:"seedUrl"`
+	PageCount   int         `json:"pageCount"`
+	Pages       []CrawlPage `json:"pages"`
+	BlockedURLs []string    `json:"blockedUrls"`
+	FailedURLs  []string    `json:"failedUrls"`
+}
+
+type CrawlOptions struct {
+	MaxPages int
+	MaxDepth int
+	Workers  int
+}
+
+var robotDisallowRegex = regexp.MustCompile(`(?im)^disallow:\s*(\S*)`)
+
+func Crawl(seed string, options CrawlOptions) *CrawlResult {
+	if options.MaxPages <= 0 {
+		options.MaxPages = 25
+	}
+	if options.MaxDepth < 0 {
+		options.MaxDepth = 2
+	}
+	if options.Workers <= 0 {
+		options.Workers = 6
+	}
+
+	res := &CrawlResult{SeedURL: seed}
+	seedURL, err := url.Parse(seed)
+	if err != nil {
+		res.FailedURLs = append(res.FailedURLs, seed)
+		return res
+	}
+	rules := fetchRobotsRules(seedURL)
+	visited := map[string]struct{}{seed: {}}
+	current := []string{seed}
+
+	for depth := 0; depth <= options.MaxDepth && len(current) > 0 && len(res.Pages) < options.MaxPages; depth++ {
+		nextLevel := make([]string, 0, options.MaxPages)
+		sem := make(chan struct{}, options.Workers)
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+
+		for _, pageURL := range current {
+			if len(res.Pages) >= options.MaxPages {
+				break
+			}
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(u string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				if !isAllowedByRobots(seedURL, rules, u) {
+					mu.Lock()
+					res.BlockedURLs = append(res.BlockedURLs, u)
+					mu.Unlock()
+					return
+				}
+
+				page, links, ok := fetchPage(u)
+				if !ok {
+					mu.Lock()
+					res.FailedURLs = append(res.FailedURLs, u)
+					mu.Unlock()
+					return
+				}
+
+				mu.Lock()
+				if len(res.Pages) < options.MaxPages {
+					res.Pages = append(res.Pages, page)
+				}
+				for _, href := range links {
+					next := resolveAndNormalize(u, href)
+					if next == "" || !sameHost(seedURL, next) {
+						continue
+					}
+					if _, seen := visited[next]; seen {
+						continue
+					}
+					visited[next] = struct{}{}
+					nextLevel = append(nextLevel, next)
+				}
+				mu.Unlock()
+			}(pageURL)
+		}
+		wg.Wait()
+		current = nextLevel
+	}
+
+	res.PageCount = len(res.Pages)
+	return res
+}
+
+func fetchPage(pageURL string) (CrawlPage, []string, bool) {
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Get(pageURL)
+	if err != nil || resp.StatusCode >= 400 {
+		return CrawlPage{}, nil, false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return CrawlPage{}, nil, false
+	}
+	html := string(body)
+	title := ""
+	if matches := titleRegex.FindStringSubmatch(html); len(matches) > 1 {
+		title = normalize(matches[1])
+	}
+	text := normalize(tagRegex.ReplaceAllString(html, " "))
+	links := make([]string, 0, 50)
+	for _, match := range linkRegex.FindAllStringSubmatch(html, 50) {
+		if len(match) > 1 {
+			links = append(links, strings.TrimSpace(match[1]))
+		}
+	}
+	return CrawlPage{URL: pageURL, Title: title, Text: text}, links, true
+}
+
+func resolveAndNormalize(base string, href string) string {
+	u, err := url.Parse(href)
+	if err != nil {
+		return ""
+	}
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return ""
+	}
+	resolved := baseURL.ResolveReference(u)
+	resolved.Fragment = ""
+	resolved.RawQuery = ""
+	if resolved.Scheme != "http" && resolved.Scheme != "https" {
+		return ""
+	}
+	return resolved.String()
+}
+
+func sameHost(seed *url.URL, candidate string) bool {
+	u, err := url.Parse(candidate)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(seed.Hostname(), u.Hostname())
+}
+
+func fetchRobotsRules(seed *url.URL) []string {
+	robotsURL := seed.Scheme + "://" + seed.Host + "/robots.txt"
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(robotsURL)
+	if err != nil || resp.StatusCode >= 400 {
+		return nil
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 200*1024))
+	if err != nil {
+		return nil
+	}
+	matches := robotDisallowRegex.FindAllStringSubmatch(string(body), -1)
+	rules := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) > 1 {
+			r := strings.TrimSpace(m[1])
+			if r != "" {
+				rules = append(rules, r)
+			}
+		}
+	}
+	return rules
+}
+
+func isAllowedByRobots(seed *url.URL, rules []string, pageURL string) bool {
+	if len(rules) == 0 {
+		return true
+	}
+	u, err := url.Parse(pageURL)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(seed.Hostname(), u.Hostname()) {
+		return false
+	}
+	path := u.EscapedPath()
+	for _, disallow := range rules {
+		if disallow == "/" || strings.HasPrefix(path, disallow) {
+			return false
+		}
+	}
+	return true
+}

--- a/backend-python/app/nlp/site_qa.py
+++ b/backend-python/app/nlp/site_qa.py
@@ -1,0 +1,115 @@
+"""Local retriever trained on crawled website data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from app.scrapers.site_crawler import DATA_DIR
+
+
+class SiteKnowledgeBase:
+    def __init__(self) -> None:
+        self.site_url: str | None = None
+        self.chunks: list[dict[str, str]] = []
+        self.vectorizer: TfidfVectorizer | None = None
+        self.matrix = None
+
+    def train_from_crawl(self, crawl_file: Path) -> dict[str, Any]:
+        payload = json.loads(crawl_file.read_text(encoding="utf-8"))
+        pages = payload.get("pages", [])
+
+        chunks: list[dict[str, str]] = []
+        for page in pages:
+            for chunk in page.get("chunks", []):
+                chunks.append(
+                    {
+                        "url": page.get("url", ""),
+                        "title": page.get("title", ""),
+                        "text": chunk,
+                    }
+                )
+
+        if not chunks:
+            self.site_url = payload.get("seed_url")
+            self.chunks = []
+            self.vectorizer = None
+            self.matrix = None
+            return {"site_url": self.site_url, "trained_chunks": 0}
+
+        corpus = [item["text"] for item in chunks]
+        vectorizer = TfidfVectorizer(stop_words="english", ngram_range=(1, 2), max_features=25000)
+        matrix = vectorizer.fit_transform(corpus)
+
+        self.site_url = payload.get("seed_url")
+        self.chunks = chunks
+        self.vectorizer = vectorizer
+        self.matrix = matrix
+
+        return {
+            "site_url": self.site_url,
+            "trained_chunks": len(chunks),
+            "page_count": len(pages),
+        }
+
+    def query(self, question: str, top_k: int = 3) -> dict[str, Any]:
+        if not question.strip():
+            return {"answer": "Question cannot be empty.", "confidence": 0.0, "matches": []}
+
+        if not self.vectorizer or self.matrix is None or not self.chunks:
+            return {
+                "answer": "No site model is trained yet. Call /site/crawl-and-train first.",
+                "confidence": 0.0,
+                "matches": [],
+            }
+
+        query_vector = self.vectorizer.transform([question])
+        similarities = cosine_similarity(query_vector, self.matrix).flatten()
+
+        if not np.any(similarities):
+            return {
+                "answer": "I could not find relevant content in the trained site corpus.",
+                "confidence": 0.0,
+                "matches": [],
+                "site_url": self.site_url,
+            }
+
+        best_indices = similarities.argsort()[::-1][: max(top_k, 1)]
+        matches = []
+        for idx in best_indices:
+            score = float(similarities[idx])
+            item = self.chunks[int(idx)]
+            matches.append(
+                {
+                    "url": item["url"],
+                    "title": item["title"],
+                    "snippet": item["text"],
+                    "score": round(score, 4),
+                }
+            )
+
+        best = matches[0]
+        return {
+            "site_url": self.site_url,
+            "answer": best["snippet"],
+            "confidence": best["score"],
+            "matches": matches,
+            "model": "local_tfidf_retriever",
+        }
+
+
+def latest_crawl_file_for_url(seed_url: str) -> Path | None:
+    candidates = sorted(DATA_DIR.glob("site_*.json"), reverse=True)
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if payload.get("seed_url") == seed_url:
+            return candidate
+    return None

--- a/backend-python/app/scrapers/site_crawler.py
+++ b/backend-python/app/scrapers/site_crawler.py
@@ -1,0 +1,277 @@
+"""Website crawler that respects robots.txt and builds a local corpus."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any
+from urllib.parse import urljoin, urlparse
+import urllib.robotparser
+
+import requests
+from bs4 import BeautifulSoup
+
+USER_AGENT = "MetaCrawler/1.0 (Educational)"
+DEFAULT_TIMEOUT_SECONDS = 15
+DEFAULT_MAX_PAGES = 25
+DEFAULT_MAX_DEPTH = 2
+MAX_CHUNK_WORDS = 160
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class CrawlResult:
+    pages: list[dict[str, Any]]
+    blocked_urls: list[str]
+    failed_urls: list[dict[str, str]]
+
+
+def _normalize_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _domain_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    return parsed.netloc.lower()
+
+
+def _safe_filename(seed_url: str) -> str:
+    digest = hashlib.sha1(seed_url.encode("utf-8")).hexdigest()[:16]
+    return f"site_{digest}.json"
+
+
+def _extract_clean_text(soup: BeautifulSoup) -> str:
+    for tag in soup(["script", "style", "noscript", "nav", "footer", "header", "aside", "form", "iframe", "svg"]):
+        tag.decompose()
+    return _normalize_whitespace(soup.get_text(separator=" ", strip=True))
+
+
+def _split_into_chunks(text: str, max_words: int = MAX_CHUNK_WORDS) -> list[str]:
+    words = text.split()
+    if not words:
+        return []
+    chunks = []
+    for i in range(0, len(words), max_words):
+        chunk = " ".join(words[i : i + max_words]).strip()
+        if chunk:
+            chunks.append(chunk)
+    return chunks
+
+
+def _build_robot_parser(start_url: str) -> urllib.robotparser.RobotFileParser:
+    parsed = urlparse(start_url)
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+    parser = urllib.robotparser.RobotFileParser()
+    parser.set_url(robots_url)
+    try:
+        parser.read()
+    except Exception:
+        pass
+    return parser
+
+
+def _normalize_pages(pages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized = []
+    for page in pages:
+        text = _normalize_whitespace(page.get("text", ""))
+        if not text:
+            continue
+        normalized.append(
+            {
+                "url": page.get("url", ""),
+                "title": _normalize_whitespace(page.get("title", "")),
+                "text": text,
+                "chunks": _split_into_chunks(text),
+            }
+        )
+    return normalized
+
+
+def crawl_site_go(seed_url: str, max_pages: int = DEFAULT_MAX_PAGES, max_depth: int = DEFAULT_MAX_DEPTH) -> CrawlResult:
+    go_service = os.getenv("GO_SERVICE_URL", "http://localhost:8080")
+    response = requests.post(
+        f"{go_service}/crawl",
+        json={"url": seed_url, "max_pages": max_pages, "max_depth": max_depth},
+        timeout=DEFAULT_TIMEOUT_SECONDS * 4,
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    pages = _normalize_pages(payload.get("pages", []))
+    blocked = payload.get("blockedUrls", [])
+    failed = [{"url": url, "error": "go_crawler_failed"} for url in payload.get("failedUrls", [])]
+    return CrawlResult(pages=pages, blocked_urls=blocked, failed_urls=failed)
+
+
+def crawl_site_python(seed_url: str, max_pages: int = DEFAULT_MAX_PAGES, max_depth: int = DEFAULT_MAX_DEPTH) -> CrawlResult:
+    robot_parser = _build_robot_parser(seed_url)
+    root_domain = _domain_from_url(seed_url)
+
+    queue: deque[tuple[str, int]] = deque([(seed_url, 0)])
+    visited: set[str] = set()
+    pages: list[dict[str, Any]] = []
+    blocked_urls: list[str] = []
+    failed_urls: list[dict[str, str]] = []
+
+    while queue and len(pages) < max_pages:
+        current_url, depth = queue.popleft()
+        if current_url in visited:
+            continue
+        visited.add(current_url)
+
+        if not robot_parser.can_fetch(USER_AGENT, current_url):
+            blocked_urls.append(current_url)
+            continue
+
+        try:
+            response = requests.get(
+                current_url,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+                headers={"User-Agent": USER_AGENT},
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            failed_urls.append({"url": current_url, "error": str(exc)})
+            continue
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        page_text = _extract_clean_text(soup)
+        if not page_text:
+            continue
+
+        title = _normalize_whitespace(soup.title.text) if soup.title else ""
+        page_chunks = _split_into_chunks(page_text)
+
+        pages.append({"url": current_url, "title": title, "text": page_text, "chunks": page_chunks})
+
+        if depth >= max_depth:
+            continue
+
+        for anchor in soup.find_all("a", href=True):
+            next_url = urljoin(current_url, anchor["href"])
+            parsed = urlparse(next_url)
+            if parsed.scheme not in {"http", "https"}:
+                continue
+            if parsed.netloc.lower() != root_domain:
+                continue
+            normalized = parsed._replace(fragment="", query="").geturl()
+            if normalized not in visited:
+                queue.append((normalized, depth + 1))
+
+    return CrawlResult(pages=pages, blocked_urls=blocked_urls, failed_urls=failed_urls)
+
+
+def crawl_site_node(seed_url: str, max_pages: int = DEFAULT_MAX_PAGES, max_depth: int = DEFAULT_MAX_DEPTH) -> CrawlResult:
+    node_service = os.getenv("NODE_SERVICE_URL", "http://localhost:3000")
+    robot_parser = _build_robot_parser(seed_url)
+    root_domain = _domain_from_url(seed_url)
+
+    queue: deque[tuple[str, int]] = deque([(seed_url, 0)])
+    visited: set[str] = set()
+    pages: list[dict[str, Any]] = []
+    blocked_urls: list[str] = []
+    failed_urls: list[dict[str, str]] = []
+
+    while queue and len(pages) < max_pages:
+        current_url, depth = queue.popleft()
+        if current_url in visited:
+            continue
+        visited.add(current_url)
+
+        if not robot_parser.can_fetch(USER_AGENT, current_url):
+            blocked_urls.append(current_url)
+            continue
+
+        try:
+            response = requests.post(
+                f"{node_service}/scrape",
+                json={"url": current_url},
+                timeout=DEFAULT_TIMEOUT_SECONDS * 4,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as exc:
+            failed_urls.append({"url": current_url, "error": str(exc)})
+            continue
+
+        raw_content = payload.get("content", [])
+        if isinstance(raw_content, list):
+            text_blob = " ".join(str(item) for item in raw_content)
+        else:
+            text_blob = str(raw_content)
+
+        page_text = _normalize_whitespace(text_blob)
+        if not page_text:
+            continue
+
+        title = _normalize_whitespace(payload.get("title", ""))
+        pages.append({
+            "url": current_url,
+            "title": title,
+            "text": page_text,
+            "chunks": _split_into_chunks(page_text),
+        })
+
+        if depth >= max_depth:
+            continue
+
+        # Use lightweight HTML fetch for link discovery only.
+        try:
+            html_response = requests.get(current_url, timeout=DEFAULT_TIMEOUT_SECONDS, headers={"User-Agent": USER_AGENT})
+            html_response.raise_for_status()
+            soup = BeautifulSoup(html_response.text, "html.parser")
+        except requests.RequestException:
+            continue
+
+        for anchor in soup.find_all("a", href=True):
+            next_url = urljoin(current_url, anchor["href"])
+            parsed = urlparse(next_url)
+            if parsed.scheme not in {"http", "https"}:
+                continue
+            if parsed.netloc.lower() != root_domain:
+                continue
+            normalized = parsed._replace(fragment="", query="").geturl()
+            if normalized not in visited:
+                queue.append((normalized, depth + 1))
+
+    return CrawlResult(pages=pages, blocked_urls=blocked_urls, failed_urls=failed_urls)
+
+
+def crawl_site(seed_url: str, max_pages: int = DEFAULT_MAX_PAGES, max_depth: int = DEFAULT_MAX_DEPTH) -> tuple[CrawlResult, str]:
+    try:
+        go_result = crawl_site_go(seed_url, max_pages=max_pages, max_depth=max_depth)
+        if go_result.pages:
+            return go_result, "go"
+    except requests.RequestException:
+        pass
+
+    python_result = crawl_site_python(seed_url, max_pages=max_pages, max_depth=max_depth)
+    if python_result.pages:
+        return python_result, "python_fallback"
+
+    node_result = crawl_site_node(seed_url, max_pages=max_pages, max_depth=max_depth)
+    return node_result, "node_fallback"
+
+
+def save_crawl(seed_url: str, crawl: CrawlResult, engine: str) -> Path:
+    payload = {
+        "seed_url": seed_url,
+        "crawled_at": datetime.now(timezone.utc).isoformat(),
+        "engine": engine,
+        "page_count": len(crawl.pages),
+        "pages": crawl.pages,
+        "blocked_urls": crawl.blocked_urls,
+        "failed_urls": crawl.failed_urls,
+    }
+    filename = _safe_filename(seed_url)
+    target = DATA_DIR / filename
+    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return target

--- a/backend-python/main.py
+++ b/backend-python/main.py
@@ -10,7 +10,9 @@ from pydantic import BaseModel, Field, HttpUrl
 
 # Import the new answer_question function
 from app.nlp.processor import analyze_text, answer_question
+from app.nlp.site_qa import SiteKnowledgeBase
 from app.scrapers.basic_scraper import scrape_url
+from app.scrapers.site_crawler import crawl_site, save_crawl
 from celery_worker import celery_app, process_nlp_task, process_quick_scrape_task
 
 app = FastAPI(title="MetaCrawler Python Service", version="1.0.0")
@@ -29,6 +31,18 @@ class ScrapePayload(BaseModel):
 class QAPayload(BaseModel):
     text: str = Field(..., min_length=1)
     question: str = Field(..., min_length=1)
+
+site_kb = SiteKnowledgeBase()
+
+class SiteTrainPayload(BaseModel):
+    url: HttpUrl
+    max_pages: int = Field(default=25, ge=1, le=200)
+    max_depth: int = Field(default=2, ge=0, le=6)
+
+class SiteQuestionPayload(BaseModel):
+    question: str = Field(..., min_length=1)
+    top_k: int = Field(default=3, ge=1, le=10)
+
 
 @app.get("/")
 def health_check() -> dict[str, str]:
@@ -80,3 +94,22 @@ def quick_scrape(payload: ScrapePayload, background_tasks: BackgroundTasks) -> d
 @app.post("/qa")
 def qa_endpoint(payload: QAPayload) -> dict[str, Any]:
     return answer_question(payload.text, payload.question)
+
+@app.post("/site/crawl-and-train")
+def crawl_and_train(payload: SiteTrainPayload) -> dict[str, Any]:
+    crawl, engine = crawl_site(str(payload.url), max_pages=payload.max_pages, max_depth=payload.max_depth)
+    crawl_file = save_crawl(str(payload.url), crawl, engine)
+    training = site_kb.train_from_crawl(crawl_file)
+    return {
+        "crawl_file": str(crawl_file),
+        "blocked_count": len(crawl.blocked_urls),
+        "failed_count": len(crawl.failed_urls),
+        "engine": engine,
+        "fallback_order": ["go", "python", "node"],
+        "training": training,
+    }
+
+
+@app.post("/site/ask")
+def ask_site(payload: SiteQuestionPayload) -> dict[str, Any]:
+    return site_kb.query(payload.question, top_k=payload.top_k)


### PR DESCRIPTION
### Motivation
- Improve crawl reliability by trying the high-performance Go crawler first, then falling back to the existing Python crawler, and finally to the Node dynamic scraper when earlier engines fail or return no pages.
- Keep the downstream flow unchanged: normalize crawl output, persist crawl metadata including the engine used, train a local retriever, and answer questions against the trained site corpus.
- Make fallback behavior explicit in persisted artifacts and API responses to aid observability and debugging.

### Description
- Implemented a new Node-based fallback crawler `crawl_site_node(...)` in `backend-python/app/scrapers/site_crawler.py` that respects `robots.txt`, calls the Node `/scrape` endpoint for extraction, normalizes content into chunks, and participates in link discovery.
- Updated Python orchestration in `crawl_site(...)` to attempt `crawl_site_go` first, then `crawl_site_python`, then `crawl_site_node`, and to return the chosen `engine` string; added `fallback_order` to the `/site/crawl-and-train` response in `backend-python/main.py`.
- Added a concurrent, robots-aware Go crawl endpoint `POST /crawl` in `backend-go/cmd/server/main.go` and a new Go crawler implementation `backend-go/internal/scraper/crawler.go` that returns structured pages, blockedUrls, and failedUrls.
- Added a local TF-IDF retriever and QA helper `backend-python/app/nlp/site_qa.py`, updated `README.md` to document the Go→Python→Node fallback, and adjusted the API gateway `api-gateway/resolvers.js` to prefer the Go static scraper and fall back to the Python quick-scrape when appropriate.

### Testing
- Compiled Python modules with `python -m compileall backend-python/main.py backend-python/app/scrapers/site_crawler.py backend-python/app/nlp/site_qa.py`, which completed successfully.
- Ran Go package checks with `cd backend-go && go test ./...`, which completed successfully (no tests but package checks passed).
- Validated the API gateway syntax with `node --check /workspace/MetaCrawler/api-gateway/resolvers.js`, which completed successfully; an earlier combined test command failed due to a path mismatch but independent checks above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6e4923cc8328a61916ba7adefe45)