### PR TITLE
Harden crawl pipeline against null Go list fields

### DIFF
--- a/backend-go/internal/scraper/crawler.go
+++ b/backend-go/internal/scraper/crawler.go
@@ -43,7 +43,12 @@ func Crawl(seed string, options CrawlOptions) *CrawlResult {
 		options.Workers = 6
 	}
 
-	res := &CrawlResult{SeedURL: seed}
+	res := &CrawlResult{
+		SeedURL:     seed,
+		Pages:       []CrawlPage{},
+		BlockedURLs: []string{},
+		FailedURLs:  []string{},
+	}
 	seedURL, err := url.Parse(seed)
 	if err != nil {
 		res.FailedURLs = append(res.FailedURLs, seed)
@@ -107,7 +112,20 @@ func Crawl(seed string, options CrawlOptions) *CrawlResult {
 	}
 
 	res.PageCount = len(res.Pages)
+	ensureNonNilSlices(res)
 	return res
+}
+
+func ensureNonNilSlices(res *CrawlResult) {
+	if res.Pages == nil {
+		res.Pages = []CrawlPage{}
+	}
+	if res.BlockedURLs == nil {
+		res.BlockedURLs = []string{}
+	}
+	if res.FailedURLs == nil {
+		res.FailedURLs = []string{}
+	}
 }
 
 func fetchPage(pageURL string) (CrawlPage, []string, bool) {

--- a/backend-go/internal/scraper/crawler_test.go
+++ b/backend-go/internal/scraper/crawler_test.go
@@ -1,0 +1,19 @@
+package scraper
+
+import "testing"
+
+func TestEnsureNonNilSlices(t *testing.T) {
+	res := &CrawlResult{}
+
+	ensureNonNilSlices(res)
+
+	if res.Pages == nil {
+		t.Fatal("expected pages to be non-nil")
+	}
+	if res.BlockedURLs == nil {
+		t.Fatal("expected blocked URLs to be non-nil")
+	}
+	if res.FailedURLs == nil {
+		t.Fatal("expected failed URLs to be non-nil")
+	}
+}

--- a/backend-python/app/scrapers/site_crawler.py
+++ b/backend-python/app/scrapers/site_crawler.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
 import json
+import logging
 import os
 from pathlib import Path
 import re
@@ -25,6 +26,8 @@ MAX_CHUNK_WORDS = 160
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -104,7 +107,7 @@ def crawl_site_go(seed_url: str, max_pages: int = DEFAULT_MAX_PAGES, max_depth: 
     payload = response.json()
 
     pages = _normalize_pages(payload.get("pages") or [])
-    blocked = payload.get("blockedUrls", [])
+    blocked = payload.get("blockedUrls") or []
     failed_urls = payload.get("failedUrls") or []
     failed = [{"url": url, "error": "go_crawler_failed"} for url in failed_urls]
     if payload.get("pages") is None:
@@ -248,12 +251,14 @@ def crawl_site_node(seed_url: str, max_pages: int = DEFAULT_MAX_PAGES, max_depth
 
 
 def crawl_site(seed_url: str, max_pages: int = DEFAULT_MAX_PAGES, max_depth: int = DEFAULT_MAX_DEPTH) -> tuple[CrawlResult, str]:
+    go_result: CrawlResult | None = None
     try:
         go_result = crawl_site_go(seed_url, max_pages=max_pages, max_depth=max_depth)
-        if go_result.pages:
-            return go_result, "go"
-    except requests.RequestException:
-        pass
+    except Exception as exc:
+        logger.warning("Go crawler failed for %s: %s", seed_url, exc)
+
+    if go_result is not None and go_result.pages:
+        return go_result, "go"
 
     python_result = crawl_site_python(seed_url, max_pages=max_pages, max_depth=max_depth)
     if python_result.pages:

--- a/backend-python/tests/test_site_crawler_resilience.py
+++ b/backend-python/tests/test_site_crawler_resilience.py
@@ -1,0 +1,57 @@
+from fastapi.testclient import TestClient
+
+import main
+from app.scrapers import site_crawler
+from app.scrapers.site_crawler import CrawlResult
+
+
+client = TestClient(main.app)
+
+
+def test_crawl_site_go_handles_null_list_fields(monkeypatch):
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"pages": None, "failedUrls": None, "blockedUrls": None}
+
+    monkeypatch.setattr(site_crawler.requests, "post", lambda *args, **kwargs: FakeResponse())
+
+    result = site_crawler.crawl_site_go("https://example.com", max_pages=5, max_depth=1)
+
+    assert result.pages == []
+    assert result.blocked_urls == []
+    assert isinstance(result.failed_urls, list)
+
+
+def test_crawl_and_train_falls_back_when_go_throws(monkeypatch):
+    def fake_go(*args, **kwargs):
+        raise RuntimeError("go unavailable")
+
+    def fake_python(*args, **kwargs):
+        return CrawlResult(
+            pages=[
+                {
+                    "url": "https://example.com",
+                    "title": "Example",
+                    "text": "Example fallback content",
+                    "chunks": ["Example fallback content"],
+                }
+            ],
+            blocked_urls=[],
+            failed_urls=[],
+        )
+
+    monkeypatch.setattr(site_crawler, "crawl_site_go", fake_go)
+    monkeypatch.setattr(site_crawler, "crawl_site_python", fake_python)
+
+    response = client.post(
+        "/site/crawl-and-train",
+        json={"url": "https://example.com", "max_pages": 5, "max_depth": 1},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["engine"] == "python_fallback"
+    assert body["training"]["trained_chunks"] > 0


### PR DESCRIPTION
### Motivation
- Production crashes occurred when the Go crawler returned JSON list fields as `null`, causing Python list iterations to raise `TypeError` and return 500s.
- The goal is to make the Python service resilient to `null` list fields, ensure the Go service encodes slices as `[]` (not `null`), and add regression tests to prevent regressions.

### Description
- Python: treat nullable list fields safely by using `payload.get("X") or []` for `pages`, `blockedUrls`, and `failedUrls`, keep `_normalize_pages(...)` returning `[]` for falsy input, add a module `logger`, and make `crawl_site()` catch any exception from `crawl_site_go()` and only select Go when it actually returned pages.
- Go: initialize `Pages`, `BlockedURLs`, and `FailedURLs` in `Crawl()` and call `ensureNonNilSlices()` before returning so JSON encoding yields arrays instead of `null`.
- Tests: add `backend-python/tests/test_site_crawler_resilience.py` to validate Go `null` payload handling and that `/site/crawl-and-train` falls back to Python when Go throws, and add `backend-go/internal/scraper/crawler_test.go` to assert slice normalization.

### Testing
- Ran Python byte-compile: `python -m compileall backend-python/app/scrapers/site_crawler.py backend-python/main.py` and it succeeded.
- Ran Go unit tests: `cd backend-go && go test ./...` and they passed (internal scraper tests OK).
- Ran Python test suite: `cd backend-python && python -m pytest -q` and test collection failed because the test environment is missing the `httpx` dependency and `pip` install is blocked by the environment proxy, so Python tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a90aae56c83288494a19077d703d2)